### PR TITLE
UglifyJS options updated to disable class name mangling

### DIFF
--- a/dist/presets/lib.mjs
+++ b/dist/presets/lib.mjs
@@ -32,7 +32,12 @@ const webpack = {
         new UglifyJsPlugin({
           cache: true,
           parallel: true,
-          sourceMap: false
+          sourceMap: false,
+          uglifyOptions: {
+            mangle: {
+              keep_classnames: true
+            }
+          }
         })
       ]
     }

--- a/dist/presets/pwa-vue.mjs
+++ b/dist/presets/pwa-vue.mjs
@@ -108,7 +108,12 @@ const webpack = {
         new UglifyJsPlugin({
           cache: true,
           parallel: true,
-          sourceMap: false
+          sourceMap: false,
+          uglifyOptions: {
+            mangle: {
+              keep_classnames: true
+            }
+          }
         }),
         new OptimizeCSSAssetsPlugin({})
       ]

--- a/dist/presets/vue.mjs
+++ b/dist/presets/vue.mjs
@@ -91,7 +91,12 @@ const webpack = {
         new UglifyJsPlugin({
           cache: true,
           parallel: true,
-          sourceMap: false
+          sourceMap: false,
+          uglifyOptions: {
+            mangle: {
+              keep_classnames: true
+            }
+          }
         }),
         new OptimizeCSSAssetsPlugin({})
       ]


### PR DESCRIPTION
Updated all build templates with a UglifyJS option to disable class name mangling to prevent issues with class name detection such as `instance.constructor.name === 'ClassName'`