### PR TITLE
A change of SVGO options

### DIFF
--- a/dist/presets/pwa-vue.mjs
+++ b/dist/presets/pwa-vue.mjs
@@ -49,7 +49,8 @@ const webpack = {
             svgo: {
               plugins: [
                 {removeDoctype: true},
-                {removeComments: true}
+                {removeComments: true},
+                {inlineStyles: false}
               ]
             }
           }

--- a/dist/presets/vue-postcss.mjs
+++ b/dist/presets/vue-postcss.mjs
@@ -45,7 +45,8 @@ const webpack = {
             svgo: {
               plugins: [
                 {removeDoctype: true},
-                {removeComments: true}
+                {removeComments: true},
+                {inlineStyles: false}
               ]
             }
           }

--- a/dist/presets/vue.mjs
+++ b/dist/presets/vue.mjs
@@ -45,7 +45,8 @@ const webpack = {
             svgo: {
               plugins: [
                 {removeDoctype: true},
-                {removeComments: true}
+                {removeComments: true},
+                {inlineStyles: false}
               ]
             }
           }


### PR DESCRIPTION
A minor change of SVGO options to make it keep all classes in SVG, no matter how many times they're used. Before, if class is used only once, SVGO will remove it and move corresponding styles as inline directly into an element.

We need this to be ably to use classes to style SVG via CSS.