### PR TITLE
Update of minifier options

### DIFF
--- a/dist/presets/app.mjs
+++ b/dist/presets/app.mjs
@@ -2,6 +2,7 @@
 This preset is to be used for building apps that are distributed to the end user.
 It includes support for JS, CSS, and Sass.
  */
+import { TERSER_OPTIONS } from './data/settings.mjs'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
 import sass from 'sass'
@@ -63,24 +64,7 @@ const webpack = {
     mode: 'production',
     optimization: {
       minimizer: [
-        new TerserPlugin({
-          cache: true,
-          terserOptions: {
-            ecma: undefined,
-            warnings: false,
-            parse: {},
-            compress: {},
-            mangle: true, // Note `mangle.properties` is `false` by default.
-            module: false,
-            output: null,
-            toplevel: false,
-            nameCache: null,
-            ie8: false,
-            keep_classnames: true,
-            keep_fnames: false,
-            safari10: false
-          }
-        }),
+        new TerserPlugin(TERSER_OPTIONS),
         new OptimizeCSSAssetsPlugin({})
       ]
     },

--- a/dist/presets/data/settings.mjs
+++ b/dist/presets/data/settings.mjs
@@ -1,0 +1,25 @@
+const TERSER_OPTIONS = {
+  cache: true,
+  terserOptions: {
+    ecma: 8,
+    warnings: false,
+    parse: {},
+    compress: {},
+    mangle: true, // Note `mangle.properties` is `false` by default.
+    module: false,
+    output: null,
+    toplevel: false,
+    nameCache: null,
+    ie8: false,
+    keep_classnames: true, // Without this class names will not be comparable with strings
+    /*
+    Without below it will be not possible to bundle minified files because of
+    "TypeError: Super expression must either be null or a function, not undefined" error.
+    Please see https://github.com/airbnb/react-dates/issues/1456 for more details.
+     */
+    keep_fnames: true, // Without this it will be
+    safari10: false
+  }
+}
+
+export { TERSER_OPTIONS }

--- a/dist/presets/data/settings.mjs
+++ b/dist/presets/data/settings.mjs
@@ -17,7 +17,7 @@ const TERSER_OPTIONS = {
     "TypeError: Super expression must either be null or a function, not undefined" error.
     Please see https://github.com/airbnb/react-dates/issues/1456 for more details.
      */
-    keep_fnames: true, // Without this it will be
+    keep_fnames: true,
     safari10: false
   }
 }

--- a/dist/presets/lib.mjs
+++ b/dist/presets/lib.mjs
@@ -2,6 +2,7 @@
 This preset is for building libraries in a UMD format.
 It includes support for JS only.
  */
+import { TERSER_OPTIONS } from './data/settings.mjs'
 import TerserPlugin from 'terser-webpack-plugin'
 import path from 'path'
 const projectRoot = process.cwd()
@@ -33,24 +34,7 @@ const webpack = {
     mode: 'production',
     optimization: {
       minimizer: [
-        new TerserPlugin({
-          cache: true,
-          terserOptions: {
-            ecma: undefined,
-            warnings: false,
-            parse: {},
-            compress: {},
-            mangle: true, // Note `mangle.properties` is `false` by default.
-            module: false,
-            output: null,
-            toplevel: false,
-            nameCache: null,
-            ie8: false,
-            keep_classnames: true,
-            keep_fnames: false,
-            safari10: false
-          }
-        })
+        new TerserPlugin(TERSER_OPTIONS)
       ]
     }
   },

--- a/dist/presets/node-lib.mjs
+++ b/dist/presets/node-lib.mjs
@@ -1,6 +1,7 @@
 /*
 This preset if for building libraries that work in a node.js environment.
  */
+import { TERSER_OPTIONS } from './data/settings.mjs'
 import TerserPlugin from 'terser-webpack-plugin'
 import path from 'path'
 const projectRoot = process.cwd()
@@ -34,24 +35,7 @@ const webpack = {
     mode: 'production',
     optimization: {
       minimizer: [
-        new TerserPlugin({
-          cache: true,
-          terserOptions: {
-            ecma: undefined,
-            warnings: false,
-            parse: {},
-            compress: {},
-            mangle: true, // Note `mangle.properties` is `false` by default.
-            module: false,
-            output: null,
-            toplevel: false,
-            nameCache: null,
-            ie8: false,
-            keep_classnames: true,
-            keep_fnames: false,
-            safari10: false
-          }
-        })
+        new TerserPlugin(TERSER_OPTIONS)
       ]
     }
   },

--- a/dist/presets/pwa-vue.mjs
+++ b/dist/presets/pwa-vue.mjs
@@ -2,6 +2,7 @@
 This preset is for building PWA applications that uses Vue.js.
 
  */
+import { TERSER_OPTIONS } from './data/settings.mjs'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
 import sass from 'sass'
@@ -108,24 +109,7 @@ const webpack = {
     mode: 'production',
     optimization: {
       minimizer: [
-        new TerserPlugin({
-          cache: true,
-          terserOptions: {
-            ecma: undefined,
-            warnings: false,
-            parse: {},
-            compress: {},
-            mangle: true, // Note `mangle.properties` is `false` by default.
-            module: false,
-            output: null,
-            toplevel: false,
-            nameCache: null,
-            ie8: false,
-            keep_classnames: true,
-            keep_fnames: false,
-            safari10: false
-          }
-        }),
+        new TerserPlugin(TERSER_OPTIONS),
         new OptimizeCSSAssetsPlugin({})
       ]
     },

--- a/dist/presets/vue-postcss.mjs
+++ b/dist/presets/vue-postcss.mjs
@@ -1,6 +1,7 @@
 /*
 Almost the same as `vue.mjs` template, but uses an additional PostCSS loader.
  */
+import { TERSER_OPTIONS } from './data/settings.mjs'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
 import sass from 'sass'
@@ -98,24 +99,7 @@ const webpack = {
     mode: 'production',
     optimization: {
       minimizer: [
-        new TerserPlugin({
-          cache: true,
-          terserOptions: {
-            ecma: undefined,
-            warnings: false,
-            parse: {},
-            compress: {},
-            mangle: true, // Note `mangle.properties` is `false` by default.
-            module: false,
-            output: null,
-            toplevel: false,
-            nameCache: null,
-            ie8: false,
-            keep_classnames: true,
-            keep_fnames: false,
-            safari10: false
-          }
-        }),
+        new TerserPlugin(TERSER_OPTIONS),
         new OptimizeCSSAssetsPlugin({})
       ]
     }

--- a/dist/presets/vue.mjs
+++ b/dist/presets/vue.mjs
@@ -1,6 +1,7 @@
 /*
 This preset is for building libraries that are using Vue.js.
  */
+import { TERSER_OPTIONS } from './data/settings.mjs'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
 import sass from 'sass'
@@ -96,24 +97,7 @@ const webpack = {
     mode: 'production',
     optimization: {
       minimizer: [
-        new TerserPlugin({
-          cache: true,
-          terserOptions: {
-            ecma: undefined,
-            warnings: false,
-            parse: {},
-            compress: {},
-            mangle: true, // Note `mangle.properties` is `false` by default.
-            module: false,
-            output: null,
-            toplevel: false,
-            nameCache: null,
-            ie8: false,
-            keep_classnames: true,
-            keep_fnames: false,
-            safari10: false
-          }
-        }),
+        new TerserPlugin(TERSER_OPTIONS),
         new OptimizeCSSAssetsPlugin({})
       ]
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alpheios-node-build",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Alpheios Node Build Library",
   "main": "dist/build.js",
   "scripts": {},


### PR DESCRIPTION
Updated Terser options to fix an error when minified files were not being able to be bundled with webpack. Please see https://github.com/airbnb/react-dates/issues/1456 for an issue similar to ours.

This error prevented webextension from bundling a production mode's minifyed code of a components lib, which, in turn, prevented us from running Vue in production mode.

For #11.

Once this will be merged, I will update components and webextension builds because they are dependent on this change.