### PR TITLE
Webpack mode injection

### DIFF
--- a/dist/modules/webpack.mjs
+++ b/dist/modules/webpack.mjs
@@ -58,9 +58,19 @@ export default function build (options) {
     BUILD_NUMBER: JSON.stringify(options.buildNumber)
   })
 
+  const prodInjectionPlugin = new webpack.DefinePlugin({
+    PRODUCTION_MODE_BUILD: true,
+    DEVELOPMENT_MODE_BUILD: false
+  })
+
+  const devInjectionPlugin = new webpack.DefinePlugin({
+    PRODUCTION_MODE_BUILD: false,
+    DEVELOPMENT_MODE_BUILD: true
+  })
+
   // Difine a plugin for injection of constants
-  productionConfig.plugins.push(injectionPlugin)
-  developmentConfig.plugins.push(injectionPlugin)
+  productionConfig.plugins.push(injectionPlugin, prodInjectionPlugin)
+  developmentConfig.plugins.push(injectionPlugin, devInjectionPlugin)
 
   if (!Array.isArray(options.modes)) {
     options.modes = [options.modes]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "alpheios-node-build",
-  "version": "2.0.0-dev.0",
+  "version": "2.2.2",
   "lockfileVersion": 1
 }


### PR DESCRIPTION
This change to `node-build` adds an injection of two variables: `PRODUCTION_MODE_BUILD` and `DEVELOPMENT_MODE_BUILD`. We can use those variables to trigger pieces of code specific for a particular mode. For example, we can use them to use either production or development configuration of LexisCS (i.e. a production build of `components` will use a production version of LexisCS, same for development).

Please let me know what do you think.