### PR TITLE
No-git-info fix

### DIFF
--- a/dist/support/build-info.mjs
+++ b/dist/support/build-info.mjs
@@ -27,7 +27,17 @@ const generateTimestamp = (datetime = Date.now()) => {
  * @returns {object} - A build number in the following format: branch-name.YYYYMMDDCCC
  */
 const generateBuildInfo = (datetime = Date.now()) => {
-  let branchName = branch.sync()
+  let branchName
+  try {
+    branchName = branch.sync()
+  } catch (err) {
+    /*
+    If build is running not from a git directory, as in the case of a zipped distributable,
+    no branch info will be available. It will result in `branch` throwing an error.
+    In that case we'll use a placeholder specified below instead of an actual branch name.
+     */
+    branchName = 'headless'
+  }
   if (branchName === 'master') {
     branchName = 'dev'
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "alpheios-node-build",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alpheios-node-build",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Alpheios Node Build Library",
   "main": "dist/builder.mjs",
   "type": "module",


### PR DESCRIPTION
Fixed an issue with build failing in a non-git directory due to branch name not available (see #38 for more details)