### PR TITLE
Remove spaces from version name with point

### DIFF
--- a/dist/support/build-info.mjs
+++ b/dist/support/build-info.mjs
@@ -46,7 +46,7 @@ const generateBuildInfo = (datetime = Date.now()) => {
   return {
     branch: branchName,
     number: timestamp,
-    name: `${branchPart}${timestamp}`.replace(' ', '_')
+    name: `${branchPart}${timestamp}`.replace(' ', '.')
   }
 }
 


### PR DESCRIPTION
This is the bug fix for 
![image](https://user-images.githubusercontent.com/12377640/112565587-0abe9e80-8e29-11eb-9a4b-119d10bec68b.png)
